### PR TITLE
Use Buffer.alloc and Buffer.from instead of new Buffer

### DIFF
--- a/src/chunk_stream/decoder.js
+++ b/src/chunk_stream/decoder.js
@@ -38,7 +38,7 @@ class ChunkStreamDecoder extends Transform {
           ...chunkHeader,
           message: this.message
         })
-        this.message = new Buffer(0)
+        this.message = Buffer.alloc(0)
       }
       this.processChunk()
     }

--- a/src/chunk_stream/encoder.js
+++ b/src/chunk_stream/encoder.js
@@ -63,7 +63,7 @@ class ChunkStreamEncoder extends Transform {
       const basicHeader = this._encodeBasicHeader()
       const messageHeader = this._encodeMessageHeader(info)
       const rawChunk = Buffer.concat([
-        new Buffer([...basicHeader, ...messageHeader]),
+        Buffer.from([...basicHeader, ...messageHeader]),
         chunk
       ])
       this.push(rawChunk)

--- a/src/control_stream.js
+++ b/src/control_stream.js
@@ -8,7 +8,7 @@ class ControlStream extends MessageStream {
   ackWindowSize(size = this.protocolParams.windowSize) {
     this.messageType = ControlStream.WINDOW_ACK_SIZE
     this.protocolParams.ackWindowSize = size
-    const res = new Buffer(4)
+    const res = Buffer.alloc(4)
     res.writeUInt32BE(size)
     this.push(res)
   }

--- a/src/handshake/rfc.js
+++ b/src/handshake/rfc.js
@@ -27,11 +27,11 @@ class RFCHandshake extends EventEmitter {
   }
 
   _resetBuffer() {
-    this._buffer = new Buffer(0)
+    this._buffer = Buffer.alloc(0)
   }
 
   c0() {
-    const packet = new Buffer(1)
+    const packet = Buffer.alloc(1)
     packet.writeUInt8(PROTOCOL_VERSION)
     return packet
   }

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,5 @@
 function generateRandomBuffer(len){
-  var packet = new Buffer(len);
+  var packet = Buffer.alloc(len);
   for (var i = 0; i < len; i++){
     var byte = Math.floor(Math.random() * 256);
     packet.writeUInt8(byte, i);


### PR DESCRIPTION
In some places these were already used, but a few new Buffer() usages were also in the code.